### PR TITLE
downgrade cibuildwheel v3.3.1 -> v2.22 for Ubuntu 16.04 compatibility

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -58,17 +58,50 @@ jobs:
           ~/Library/Caches/pip
           ~/.cache/pip
           ~/AppData/Local/pip/Cache
-        key: cibw-pip-${{ matrix.os }}-${{ hashFiles('pyproject.toml') }}
+          ~/Library/Caches/cibuildwheel
+          ~/.cache/cibuildwheel
+          ~/AppData/Local/pypa/cibuildwheel/Cache
+        key: cibw-${{ matrix.os }}-${{ hashFiles('pyproject.toml') }}
         restore-keys: |
-          cibw-pip-${{ matrix.os }}-
+          cibw-${{ matrix.os }}-
 
-    - uses: pypa/cibuildwheel@v3.3.1
+    - uses: astral-sh/setup-uv@v7
+
+    - name: Pre-cache virtualenv for cibuildwheel
+      shell: bash
+      run: |
+        # cibuildwheel downloads virtualenv.pyz from GitHub which can hit 429 rate limits.
+        # Pre-download with GITHUB_TOKEN auth (5000 req/hr vs 60 unauthenticated).
+        # Versions must match cibuildwheel v2.22 virtualenv.toml.
+        case "$RUNNER_OS" in
+          Windows) CACHE_DIR="$(cygpath "$USERPROFILE/AppData/Local/pypa/cibuildwheel/Cache")" ;;
+          macOS)   CACHE_DIR="$HOME/Library/Caches/cibuildwheel" ;;
+          *)       CACHE_DIR="$HOME/.cache/cibuildwheel" ;;
+        esac
+        mkdir -p "$CACHE_DIR"
+        for VERSION in 20.27.1 20.21.1; do
+          FILE="$CACHE_DIR/virtualenv-${VERSION}.pyz"
+          if [ ! -f "$FILE" ]; then
+            echo "Downloading virtualenv-${VERSION}.pyz..."
+            curl -fsSL --retry 5 --retry-delay 10 --retry-all-errors \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              "https://raw.githubusercontent.com/pypa/get-virtualenv/${VERSION}/public/virtualenv.pyz" \
+              -o "$FILE"
+          else
+            echo "virtualenv-${VERSION}.pyz already cached"
+          fi
+        done
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+
+    - uses: pypa/cibuildwheel@v2.22
       env:
         CIBW_ARCHS_MACOS: universal2
         CIBW_ARCHS_WINDOWS: AMD64 ARM64
-        CIBW_SKIP: "pp* *musllinux* *_i686 cp314t-win*"
-        CIBW_TEST_SKIP: "*macosx* *win* *aarch64 cp314t-*"
-        CIBW_BEFORE_BUILD: "pip install --prefer-binary pytest"
+        CIBW_SKIP: "pp* *musllinux* *_i686"
+        CIBW_TEST_SKIP: "*macosx* *win* *aarch64"
+        # Use uv to avoid transient GitHub rate limits during build
+        CIBW_BUILD_FRONTEND: "build[uv]"
 
     - name: Verify clean directory
       run: git diff --exit-code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "fast_viterbi"
-version = "0.1.3"
+version = "0.1.4"
 description="a viterbi algo collection"
 readme = "README.md"
 authors = [

--- a/src/fast_viterbi/_core.pyi
+++ b/src/fast_viterbi/_core.pyi
@@ -1,77 +1,89 @@
 """
 
-        Pybind11 example plugin
-        -----------------------
+Pybind11 example plugin
+-----------------------
 
-        .. currentmodule:: scikit_build_example
+.. currentmodule:: scikit_build_example
 
-        .. autosummary::
-           :toctree: _generate
+.. autosummary::
+   :toctree: _generate
 
-           FastViterbi
-    
+   FastViterbi
+
 """
+
 from __future__ import annotations
+
 import typing
-__all__: list[str] = ['FastViterbi']
+
+__all__: list[str] = ["FastViterbi"]
+
 class FastViterbi:
-    def __init__(self, K: int, N: int, scores: dict[tuple[tuple[int, int], tuple[int, int]], float]) -> None:
+    def __init__(
+        self,
+        K: int,
+        N: int,
+        scores: dict[tuple[tuple[int, int], tuple[int, int]], float],
+    ) -> None:
         """
-                     Initialize FastViterbi object.
-        
-                     Args:
-                         K (int): Number of nodes per layer.
-                         N (int): Number of layers.
-                         scores (dict): Scores for node transitions.
+        Initialize FastViterbi object.
+
+        Args:
+            K (int): Number of nodes per layer.
+            N (int): Number of layers.
+            scores (dict): Scores for node transitions.
         """
     def all_road_paths(self) -> list[list[int]]:
         """
-                     Get all road paths.
-        
-                     Returns:
-                         list: All road paths in the graph.
+        Get all road paths.
+
+        Returns:
+            list: All road paths in the graph.
         """
     @typing.overload
     def inference(self) -> tuple[float, list[int]]:
         """
-                     Perform inference without a road path.
-        
-                     Returns:
-                         tuple: Best path and its score.
+        Perform inference without a road path.
+
+        Returns:
+            tuple: Best path and its score.
         """
     @typing.overload
     def inference(self, road_path: list[int]) -> tuple[float, list[int], list[int]]:
         """
-                     Perform inference with a given road path.
-        
-                     Args:
-                         road_path (list): List of road indices representing a path.
-        
-                     Returns:
-                         tuple: Best path and its score.
+        Perform inference with a given road path.
+
+        Args:
+            road_path (list): List of road indices representing a path.
+
+        Returns:
+            tuple: Best path and its score.
         """
     def scores(self, node_path: list[int]) -> list[float]:
         """
-                     Get scores for a given node path.
-        
-                     Args:
-                         node_path (list): List of node indices representing a path.
-        
-                     Returns:
-                         float: Total score for the given path.
+        Get scores for a given node path.
+
+        Args:
+            node_path (list): List of node indices representing a path.
+
+        Returns:
+            float: Total score for the given path.
         """
     def setup_roads(self, roads: list[list[int]]) -> bool:
         """
-                     Set up roads for the Viterbi algorithm.
-        
-                     Args:
-                         roads (list): List of road sequences.
+        Set up roads for the Viterbi algorithm.
+
+        Args:
+            roads (list): List of road sequences.
         """
-    def setup_shortest_road_paths(self, sp_paths: dict[tuple[tuple[int, int], tuple[int, int]], list[int]]) -> bool:
+    def setup_shortest_road_paths(
+        self, sp_paths: dict[tuple[tuple[int, int], tuple[int, int]], list[int]]
+    ) -> bool:
         """
-                     Set up shortest road paths.
-        
-                     Args:
-                         sp_paths (dict): Dictionary of shortest paths between nodes.
+        Set up shortest road paths.
+
+        Args:
+            sp_paths (dict): Dictionary of shortest paths between nodes.
         """
-__version__: str = '0.1.4'
+
+__version__: str = "0.1.4"

--- a/src/fast_viterbi/_core.pyi
+++ b/src/fast_viterbi/_core.pyi
@@ -1,89 +1,77 @@
 """
 
-Pybind11 example plugin
------------------------
+        Pybind11 example plugin
+        -----------------------
 
-.. currentmodule:: scikit_build_example
+        .. currentmodule:: scikit_build_example
 
-.. autosummary::
-   :toctree: _generate
+        .. autosummary::
+           :toctree: _generate
 
-   FastViterbi
-
+           FastViterbi
+    
 """
-
 from __future__ import annotations
-
 import typing
-
-__all__: list[str] = ["FastViterbi"]
-
+__all__: list[str] = ['FastViterbi']
 class FastViterbi:
-    def __init__(
-        self,
-        K: int,
-        N: int,
-        scores: dict[tuple[tuple[int, int], tuple[int, int]], float],
-    ) -> None:
+    def __init__(self, K: int, N: int, scores: dict[tuple[tuple[int, int], tuple[int, int]], float]) -> None:
         """
-        Initialize FastViterbi object.
-
-        Args:
-            K (int): Number of nodes per layer.
-            N (int): Number of layers.
-            scores (dict): Scores for node transitions.
+                     Initialize FastViterbi object.
+        
+                     Args:
+                         K (int): Number of nodes per layer.
+                         N (int): Number of layers.
+                         scores (dict): Scores for node transitions.
         """
     def all_road_paths(self) -> list[list[int]]:
         """
-        Get all road paths.
-
-        Returns:
-            list: All road paths in the graph.
+                     Get all road paths.
+        
+                     Returns:
+                         list: All road paths in the graph.
         """
     @typing.overload
     def inference(self) -> tuple[float, list[int]]:
         """
-        Perform inference without a road path.
-
-        Returns:
-            tuple: Best path and its score.
+                     Perform inference without a road path.
+        
+                     Returns:
+                         tuple: Best path and its score.
         """
     @typing.overload
     def inference(self, road_path: list[int]) -> tuple[float, list[int], list[int]]:
         """
-        Perform inference with a given road path.
-
-        Args:
-            road_path (list): List of road indices representing a path.
-
-        Returns:
-            tuple: Best path and its score.
+                     Perform inference with a given road path.
+        
+                     Args:
+                         road_path (list): List of road indices representing a path.
+        
+                     Returns:
+                         tuple: Best path and its score.
         """
     def scores(self, node_path: list[int]) -> list[float]:
         """
-        Get scores for a given node path.
-
-        Args:
-            node_path (list): List of node indices representing a path.
-
-        Returns:
-            float: Total score for the given path.
+                     Get scores for a given node path.
+        
+                     Args:
+                         node_path (list): List of node indices representing a path.
+        
+                     Returns:
+                         float: Total score for the given path.
         """
     def setup_roads(self, roads: list[list[int]]) -> bool:
         """
-        Set up roads for the Viterbi algorithm.
-
-        Args:
-            roads (list): List of road sequences.
+                     Set up roads for the Viterbi algorithm.
+        
+                     Args:
+                         roads (list): List of road sequences.
         """
-    def setup_shortest_road_paths(
-        self, sp_paths: dict[tuple[tuple[int, int], tuple[int, int]], list[int]]
-    ) -> bool:
+    def setup_shortest_road_paths(self, sp_paths: dict[tuple[tuple[int, int], tuple[int, int]], list[int]]) -> bool:
         """
-        Set up shortest road paths.
-
-        Args:
-            sp_paths (dict): Dictionary of shortest paths between nodes.
+                     Set up shortest road paths.
+        
+                     Args:
+                         sp_paths (dict): Dictionary of shortest paths between nodes.
         """
-
-__version__: str = "0.1.3"
+__version__: str = '0.1.4'

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -4,4 +4,4 @@ import fast_viterbi as m
 
 
 def test_version():
-    assert m.__version__ == "0.1.3"
+    assert m.__version__ == "0.1.4"


### PR DESCRIPTION
cibuildwheel v3.x defaults to manylinux_2_28 (glibc >= 2.28) which is incompatible with Ubuntu 16.04 (glibc 2.23). v2.22 uses manylinux2014 (glibc >= 2.17) which works on Ubuntu 16.04.

Also add uv + virtualenv pre-caching to prevent GitHub rate-limit (429) failures that affect cibuildwheel v2.x builds.